### PR TITLE
Fix: Remove trailing period in diagnostics message.

### DIFF
--- a/Define.SourceGen/Diagnostics.cs
+++ b/Define.SourceGen/Diagnostics.cs
@@ -21,7 +21,7 @@ internal static class Diagnostics
     public static readonly DiagnosticDescriptor ClassNotPartial = new DiagnosticDescriptor(
         id: "DEFS0002",
         title: "The containing type must be partial",
-        messageFormat: "This type that declares this member must be partial in order to use the {0} attribute.",
+        messageFormat: "This type that declares this member must be partial in order to use the {0} attribute",
         category: CATEGORY,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true


### PR DESCRIPTION
This is a change required by newer version of Microsoft.CodeAnalysis.